### PR TITLE
#65 - Refactor: 기본 프로필 이미지 컴포넌트화

### DIFF
--- a/src/components/BasicProfileImg.css
+++ b/src/components/BasicProfileImg.css
@@ -1,0 +1,20 @@
+.basicProfileImg {
+    border-radius: 50%;
+}
+
+.basicProfileImg.lg {
+    width: 110px;
+    height: 110px;
+}
+.basicProfileImg.md {
+    width: 50px;
+    height: 50px;
+}
+.basicProfileImg.sm {
+    width: 42px;
+    height: 42px;
+}
+.basicProfileImg.xs {
+    width: 36px;
+    height: 36px;
+}

--- a/src/components/BasicProfileImg.jsx
+++ b/src/components/BasicProfileImg.jsx
@@ -1,0 +1,12 @@
+import "./BasicProfileImg.css";
+import BasicProfile from "../assets/basic-profile-img.svg";
+
+export default function BasicProfileImg(props) {
+    return (
+        <img
+            src={BasicProfile}
+            alt=""
+            className={`basicProfileImg ${props.size}`}
+        />
+    );
+}

--- a/src/components/ProfileForm.jsx
+++ b/src/components/ProfileForm.jsx
@@ -1,11 +1,10 @@
 import "./ProfileForm.css";
-import BasicProfileImg from "../assets/basic-profile-img.svg";
-
+import BasicProfileImg from "./BasicProfileImg";
 export default function ProfileForm() {
     return (
         <form className="profileForm">
             <div className="profileImgSetting">
-                <img src={BasicProfileImg} alt="프로필 이미지" className="profileImg" />
+                <BasicProfileImg size="lg" />
                 <label for="uploadFile" />
                 <input type="file" id="uploadFile" />
             </div>
@@ -23,8 +22,12 @@ export default function ProfileForm() {
                     type="text"
                     placeholder="영문, 숫자, 특수문자(.),(_)만 사용 가능합니다."
                 />
-                <strong className="cautionText">*영문, 숫자, 밑줄 및 마침표만 사용할 수 있습니다.</strong>
-                <strong className="cautionText">*이미 사용 중인 ID입니다.</strong>
+                <strong className="cautionText">
+                    *영문, 숫자, 밑줄 및 마침표만 사용할 수 있습니다.
+                </strong>
+                <strong className="cautionText">
+                    *이미 사용 중인 ID입니다.
+                </strong>
             </div>
             <div className="wrapInput">
                 <label for="">소개</label>
@@ -34,5 +37,5 @@ export default function ProfileForm() {
                 />
             </div>
         </form>
-    )
+    );
 }

--- a/src/components/feed/Post.css
+++ b/src/components/feed/Post.css
@@ -14,19 +14,11 @@
     align-items: center;
 }
 
-.postWriter .postWriterImg {
-    background: url(../../assets/basic-profile-img.svg) no-repeat center/contain;
-    width: 42px;
-    height: 42px;
-    margin-right: 12px;
-    flex-shrink: 0;
-    display: inline-block;
-}
-
 .postWriter .postWriterName {
     display: flex;
     flex-direction: column;
     width: 100%;
+    margin-left: 12px;
 }
 
 .postWriterName strong {

--- a/src/components/feed/Post.jsx
+++ b/src/components/feed/Post.jsx
@@ -1,12 +1,13 @@
 import "./Post.css";
 import Like from "../Like";
+import BasicProfileImg from "../BasicProfileImg";
 
 export default function Post() {
     return (
         <article className="postCard">
             <div className="postHeaderWrap">
                 <div className="postWriter">
-                    <div className="postWriterImg"></div>
+                    <BasicProfileImg size="sm" />
                     <div className="postWriterName">
                         <strong>애월읍 위니브 감귤농장</strong>
                         <small>@ weniv_Mandarin</small>

--- a/src/components/feed/PostComment.css
+++ b/src/components/feed/PostComment.css
@@ -4,16 +4,9 @@
     justify-content: space-between;
 }
 
-.postCommentWrap .writerImg {
-    background: url(../../assets/icon/Ellipse\ 4.svg);
-    width: 36px;
-    height: 36px;
-    border-radius: 50%;
-    margin-right: 12px;
-    flex-shrink: 0;
-}
 .comment {
     width: 100%;
+    margin-left: 12px;
 }
 
 .comment strong {

--- a/src/components/feed/PostComment.jsx
+++ b/src/components/feed/PostComment.jsx
@@ -1,9 +1,10 @@
 import "./PostComment.css";
+import BasicProfileImg from "../BasicProfileImg";
 
 export default function PostComment() {
     return (
         <div className="postCommentWrap">
-            <button className="writerImg"></button>
+            <BasicProfileImg size="xs" />
             <div className="comment">
                 <strong>서귀포시 무슨 농장</strong>
                 <span>5분 전</span>

--- a/src/components/profile/ProfileInfo.css
+++ b/src/components/profile/ProfileInfo.css
@@ -9,6 +9,7 @@
 
 .tempWrap {
     display: flex;
+    gap: 40px;
     align-items: center;
     justify-content: center;
     width: 100%;
@@ -22,10 +23,6 @@
 
 .tempWrap .followName {
     color: var(--sub-font-color);
-}
-
-.tempWrap .userImage {
-    margin: 0 40px;
 }
 
 .profileWrap .userName {

--- a/src/components/profile/ProfileInfo.jsx
+++ b/src/components/profile/ProfileInfo.jsx
@@ -1,7 +1,7 @@
 import React from "react";
-import basicProfile from "../../assets/basic-profile-img.svg";
 import ProfileBtn from "./ProfileBtn";
 import "./ProfileInfo.css";
+import BasicProfileImg from "../BasicProfileImg";
 function ProfileInfo() {
     return (
         <div className="infoWrap">
@@ -10,7 +10,7 @@ function ProfileInfo() {
                     <p className="followCount followers">2950</p>
                     <p className="followName followers">followers</p>
                 </a>
-                <img className="userImage" src={basicProfile} alt="" />
+                <BasicProfileImg size="lg" />
                 <a href="/">
                     <p className="followCount following">128</p>
                     <p className="followName following">followings</p>

--- a/src/pages/ProfileSettingPage.css
+++ b/src/pages/ProfileSettingPage.css
@@ -10,7 +10,7 @@
 }
 
 .profileSettingPage > p {
-    margin-top: 12px;
+    margin: 12px 0 30px;
     color: var(--sub-font-color);
     font-weight: 400;
     font-size: 14px;
@@ -22,7 +22,7 @@
     background-color: var(--main-bg-color);
     width: 100%;
     padding: 13px 0;
-    color: #FFFFFF;
+    color: #ffffff;
     font-weight: 500;
     font-size: 14px;
     line-height: 18px;

--- a/src/pages/ProfileSettingPage.jsx
+++ b/src/pages/ProfileSettingPage.jsx
@@ -1,5 +1,5 @@
 import "./ProfileSettingPage.css";
-import ProfileForm from "./ProfileForm";
+import ProfileForm from "../components/ProfileForm";
 
 export default function ProfileSetting() {
     return (


### PR DESCRIPTION
기본 이미지 컴포넌트화 한 후 기존에 사용되었던 파일도 수정했습니다.

기타 사항
- 피드 검색 결과로 나오는 사용자 컴포넌트는 아직 없는 파일이라 추후 검색 기능(선택 기능) 구현하게 되면 md 사이즈로 사용하면 될 것 같습니다!
- 프로필 설정 페이지처럼 기본 이미지랑 파일 추가가 붙어있는 경우, 수진님께서 파일 전송 컴포넌트 완성하신 이후에 세부 조정이 필요할 것 같아 파일 관련해서는 따로 위치 조정하지 않았습니다.

close #65 