### PR TITLE
#234 - Fix: 채팅, 댓글 말줄임 및 wrap 추가

### DIFF
--- a/src/components/chat/ChatItem.css
+++ b/src/components/chat/ChatItem.css
@@ -32,21 +32,32 @@
 }
 
 .chatContent strong {
+    width: 300px;
     font-size: 14px;
     font-weight: 600;
     text-align: left;
+    margin-bottom: 0.3rem;
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .chatContent p {
+    width: 300px;
     font-size: 12px;
     color: var(--sub-font-color);
     margin-top: 4px;
     text-align: left;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .chatItem .chatDate {
     color: var(--main-border-color);
     font-size: 10px;
     align-self: flex-end;
+    padding-bottom: 6px;
     flex-shrink: 0;
 }

--- a/src/components/comment/PostComment.css
+++ b/src/components/comment/PostComment.css
@@ -1,7 +1,8 @@
 .postCommentWrap {
     display: flex;
     padding: 18px 16px;
-    max-width: 390px;
+    /* max-width: 390px; */
+    width: 390px;
     justify-content: space-between;
     margin: 0 auto;
 }
@@ -37,6 +38,9 @@
 .comment p {
     font-size: 14px;
     margin-top: 10px;
+    overflow-wrap: break-word;
+    max-width: 300px;
+    line-height: 1.5;
 }
 
 .postCommentWrap .showModal {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/80025366/181680482-abb1c44e-e2d1-4101-8a0e-1ceee9cf32d8.png)
![image](https://user-images.githubusercontent.com/80025366/181680522-3b87e149-ea80-43f4-9634-66a487ac2a77.png)

- 댓글: `overflow-wrap: break-word`로 밑에 wrap되어 이어지게 하고
- 채팅 아이템: `text-overflow`와 `overflow`로 말줄임 처리했습니다.

close #234 