### PR TITLE
#292 - 팔로우 팔로잉 리스트에서 tapmenu에 의해 가려지는 내용 수정

### DIFF
--- a/src/pages/style/FollowerList.css
+++ b/src/pages/style/FollowerList.css
@@ -2,6 +2,10 @@
     width: 100%;
 }
 
+.followContainer {
+    padding-bottom: 60px;
+}
+
 .topMainNavFollow p {
     margin-left: 8px;
     font-size: 14px;


### PR DESCRIPTION
팔로잉리스트에서 하단에 있는 내용이 tapmenu에 의해 가려지는 현상을 해결했습니다.

closes #292 